### PR TITLE
ensure primary keys are set when initialising the db

### DIFF
--- a/utils/utility.go
+++ b/utils/utility.go
@@ -55,7 +55,8 @@ func SetupStateDB(db *sql.DB) error {
 	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS state
 	(
 		possum varchar(255),
-		state varchar(255)
+		state varchar(255),
+		PRIMARY KEY(possum)
 	)`)
 
 	if err != nil {


### PR DESCRIPTION
What:
- ensure that primary keys are set when initialising the db

Why:
- makes pxc happy
- probably best practice anyway

How to review:
- deploy into an env that uses pxc as backing, change some passels around
- merge